### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod .
 RUN go mod download
 
 COPY . ./
-RUN go build -o ./bin/nri-rabbitmq src/; strip ./bin/nri-rabbitmq
+RUN go build -o ./bin/nri-rabbitmq ./src; strip ./bin/nri-rabbitmq
 
 
 FROM newrelic/infrastructure:latest


### PR DESCRIPTION
go build should use a directory prefix to avoid searching for the source/package in GOROOT, otherwise the build will fail.